### PR TITLE
Chezmoi: Use uv to run Python scripts

### DIFF
--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -4,6 +4,10 @@
 [diff]
     exclude = ["scripts"]
 
+[interpreters.py]
+    command = "uv"
+    args = ["--quiet", "run", "--script"]
+
 # chezmoi provides a hooks.read-source-state.pre hook that allows you to modify
 # your system after chezmoi init has cloned your dotfile repo but before chezmoi
 # has read the source state. This is the perfect time to install your password


### PR DESCRIPTION
## Summary

Chezmoi does not use the shebang line when executing scripts — it uses its own interpreter configuration instead. Without this, `.py` scripts are run with bare Python, bypassing the `#!/usr/bin/env -S uv --quiet run --script` shebang and failing to auto-install PEP 723 inline dependencies like `click` and `pyyaml`.

This adds an `[interpreters.py]` section to the chezmoi config so `.py` scripts are run via `uv run --script`, which honors inline script metadata and auto-installs declared dependencies.

Fixes `typos_propagation.py` failing with `ModuleNotFoundError: No module named 'click'`.